### PR TITLE
Handle canceled tasks without retry

### DIFF
--- a/threading/ConvergeWait.cs
+++ b/threading/ConvergeWait.cs
@@ -86,6 +86,14 @@ public sealed class ConvergeWait : IConvergeWait
                         OnCompleted?.Invoke(completed);
                         break;
                     }
+                    catch (OperationCanceledException oce)
+                    {
+                        attempts++;
+                        _logger?.LogWarning(oce, "Task canceled on attempt {Attempt}", attempts);
+                        lock (_lock) _exceptions.Add(oce);
+                        OnError?.Invoke(oce);
+                        break;
+                    }
                     catch (Exception ex)
                     {
                         attempts++;


### PR DESCRIPTION
## Summary
- treat `OperationCanceledException` as a terminal failure without retry
- test that cancelled tasks are recorded as failures and not retried

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689508486a508325a14b3a2d4734537a