### PR TITLE
Harden DisposeAsync and clamp exponential retry backoff; add tests

### DIFF
--- a/threading/IConvergeWait.cs
+++ b/threading/IConvergeWait.cs
@@ -27,6 +27,11 @@ public interface IConvergeWait : IAsyncDisposable
     event Action<int>? OnConcurrencyChanged;
 
     /// <summary>
+    /// Raised when progress percentage changes. Parameter is the percent value (0-100).
+    /// </summary>
+    event Action<double>? OnProgress;
+
+    /// <summary>
     /// Total number of tasks that have been queued.
     /// </summary>
     int TotalQueued { get; }
@@ -52,6 +57,11 @@ public interface IConvergeWait : IAsyncDisposable
     IReadOnlyList<Exception> Exceptions { get; }
 
     /// <summary>
+    /// Percentage of completed tasks out of total queued (0-100).
+    /// </summary>
+    double ProgressPercent { get; }
+
+    /// <summary>
     /// Sets the retry policy for failed tasks.
     /// </summary>
     /// <param name="policy">The retry policy to apply to subsequent task failures.</param>
@@ -62,6 +72,13 @@ public interface IConvergeWait : IAsyncDisposable
     /// </summary>
     /// <param name="workItem">The async work to execute.</param>
     void Queue(Func<Task> workItem);
+
+    /// <summary>
+    /// Queues a task for execution asynchronously, waiting for a concurrency slot before scheduling.
+    /// </summary>
+    /// <param name="workItem">The async work to execute.</param>
+    /// <param name="ct">Cancellation token for the enqueue operation.</param>
+    Task QueueAsync(Func<Task> workItem, CancellationToken ct = default);
 
     /// <summary>
     /// Waits for all currently queued tasks to complete.

--- a/threading/RetryMode.cs
+++ b/threading/RetryMode.cs
@@ -3,5 +3,6 @@ namespace pengdows.threading;
 public enum RetryMode
 {
     None,
-    RetryXTimes
+    RetryXTimes,
+    ExponentialBackoff
 }

--- a/threading/RetryPolicy.cs
+++ b/threading/RetryPolicy.cs
@@ -6,7 +6,14 @@ namespace pengdows.threading;
 /// <param name="Mode">The retry mode (None or RetryXTimes).</param>
 /// <param name="MaxRetries">Maximum number of retry attempts (default: 3).</param>
 /// <param name="RetryDelay">Delay between retry attempts (default: 100ms).</param>
-public record RetryPolicy(RetryMode Mode, int MaxRetries = 3, TimeSpan RetryDelay = default)
+/// <param name="MaxDelay">Maximum delay for exponential backoff (optional).</param>
+/// <param name="BackoffMultiplier">Multiplier for exponential backoff (default: 2.0).</param>
+public record RetryPolicy(
+    RetryMode Mode,
+    int MaxRetries = 3,
+    TimeSpan RetryDelay = default,
+    TimeSpan? MaxDelay = null,
+    double BackoffMultiplier = 2.0)
 {
     /// <summary>
     /// Default retry delay used when not specified.
@@ -17,6 +24,24 @@ public record RetryPolicy(RetryMode Mode, int MaxRetries = 3, TimeSpan RetryDela
     /// Gets the effective retry delay, using 100ms if not explicitly set.
     /// </summary>
     public TimeSpan EffectiveRetryDelay => RetryDelay == default ? DefaultRetryDelay : RetryDelay;
+
+    /// <summary>
+    /// Gets the delay for the specified retry attempt.
+    /// </summary>
+    /// <param name="attempt">The 1-based attempt number.</param>
+    public TimeSpan GetDelay(int attempt)
+    {
+        if (attempt < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(attempt));
+        }
+
+        return Mode switch
+        {
+            RetryMode.ExponentialBackoff => GetExponentialDelay(attempt),
+            _ => EffectiveRetryDelay
+        };
+    }
 
     /// <summary>
     /// No retry - task fails immediately on first error.
@@ -30,4 +55,40 @@ public record RetryPolicy(RetryMode Mode, int MaxRetries = 3, TimeSpan RetryDela
     /// <param name="delay">Delay between retries (default: 100ms).</param>
     public static RetryPolicy Retry(int times, TimeSpan? delay = null) =>
         new(RetryMode.RetryXTimes, times, delay ?? DefaultRetryDelay);
+
+    /// <summary>
+    /// Creates a retry policy with exponential backoff.
+    /// </summary>
+    /// <param name="maxRetries">Maximum number of retry attempts.</param>
+    /// <param name="initialDelay">Initial delay before retrying (default: 100ms).</param>
+    /// <param name="maxDelay">Maximum delay between retries (optional).</param>
+    /// <param name="multiplier">Exponent multiplier (default: 2.0).</param>
+    public static RetryPolicy Exponential(
+        int maxRetries = 5,
+        TimeSpan? initialDelay = null,
+        TimeSpan? maxDelay = null,
+        double multiplier = 2.0) =>
+        new(RetryMode.ExponentialBackoff, maxRetries, initialDelay ?? DefaultRetryDelay, maxDelay, multiplier);
+
+    private TimeSpan GetExponentialDelay(int attempt)
+    {
+        var baseDelay = EffectiveRetryDelay;
+        var factor = Math.Pow(BackoffMultiplier, attempt - 1);
+        var maxDelay = MaxDelay ?? TimeSpan.MaxValue;
+        var baseDelayMs = baseDelay.TotalMilliseconds;
+        var maxDelayMs = maxDelay.TotalMilliseconds;
+        var delayMs = baseDelayMs * factor;
+
+        if (double.IsNaN(delayMs) || double.IsInfinity(delayMs) || delayMs >= maxDelayMs)
+        {
+            return maxDelay;
+        }
+
+        if (delayMs <= 0)
+        {
+            return TimeSpan.Zero;
+        }
+
+        return TimeSpan.FromMilliseconds(delayMs);
+    }
 }


### PR DESCRIPTION
### Motivation
- Prevent races and leaks when disposing while `QueueAsync` waiters exist by cancelling pending enqueue operations and awaiting in-flight tasks before disposing the semaphore.  
- Avoid overflow/NaN and unbounded delays from the exponential backoff calculation in `RetryPolicy`, and make `GetDelay` safe for pathological multipliers.  
- Add unit tests that cover the disposal / pending-queue cancellation and edge cases in retry backoff and max-retries semantics.

### Description
- Added a dedicated `_disposeCts` and included it in enqueue-linked tokens via `CancellationTokenSource.CreateLinkedTokenSource(_cancellationToken, ct, _disposeCts.Token)` so pending `QueueAsync` calls are cancelled on dispose and do not leak slots.  
- In `DisposeAsync` now cancel `_disposeCts`, cancel the internal monitor, capture a snapshot of `_tasks`, `await Task.WhenAll(snapshot)` (suppressing exceptions) and only then dispose the semaphore and CTS instances to avoid races.  
- Hardened `RetryPolicy.GetExponentialDelay` to compute `delayMs` as `baseDelay.TotalMilliseconds * factor`, detect `NaN`/`Infinity`/overflow and clamp to `MaxDelay` or `TimeSpan.MaxValue`, and return `TimeSpan.Zero` for non-positive results. Also exposed `GetDelay(int)` and added the `Exponential(...)` factory.  
- Added/updated unit tests in `threading.Tests/ConvergeWaitTests.cs` covering `QueueAsync` backpressure/disposal cancellation and retry behavior edge-cases (see test names below).

### Testing
- Attempted `dotnet build` and `dotnet test` but the environment does not provide the .NET SDK so builds/tests could not be executed here (commands attempted: `dotnet build`, `dotnet test`).  
- Added automated unit tests; notable new tests are: `QueueAsync_DisposeAsync_CancelsPendingQueue`, `RetryPolicy_ExponentialBackoff_ClampsToTimeSpanMaxValue`, and `RetryPolicy_ZeroMaxRetries_DoesNotRetry`, plus supporting adjustments to existing coverage in `threading.Tests/ConvergeWaitTests.cs`.  
- These tests should be executed with `dotnet test` in a .NET-capable environment and are expected to validate the disposal cancellation behavior and the corrected exponential backoff behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a4578d2e883259e2f35dfe71ddd67)